### PR TITLE
Deprecate unused --nodeid flag

### DIFF
--- a/cmd/csi-bizflycloud/main.go
+++ b/cmd/csi-bizflycloud/main.go
@@ -36,7 +36,6 @@ import (
 
 var (
 	endpoint       string
-	nodeID         string
 	authMethod     string
 	username       string
 	password       string
@@ -86,7 +85,7 @@ func main() {
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 
 	cmd.PersistentFlags().StringVar(&nodeID, "nodeid", "", "node id")
-	cmd.MarkPersistentFlagRequired("nodeid")
+	cmd.PersistentFlags().MarkDeprecated("nodeid", "This flag would be removed in future. Currently, the value is ignored by the driver")
 
 	cmd.PersistentFlags().StringVar(&endpoint, "endpoint", "", "CSI endpoint")
 	cmd.MarkPersistentFlagRequired("endpoint")
@@ -124,7 +123,7 @@ func main() {
 
 func handle() {
 
-	d := driver.NewDriver(nodeID, endpoint, cluster)
+	d := driver.NewDriver(endpoint, cluster)
 
 	// Intiliaze mount
 	iMount := mount.GetMountProvider()

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -36,7 +36,6 @@ var (
 
 type VolumeDriver struct {
 	name     string
-	nodeID   string
 	version  string
 	endpoint string
 	cluster  string
@@ -51,12 +50,11 @@ type VolumeDriver struct {
 }
 
 // NewDriver create new driver
-func NewDriver(nodeID, endpoint, cluster string) *VolumeDriver {
+func NewDriver(endpoint, cluster string) *VolumeDriver {
 	klog.Infof("Driver: %v version: %v", driverName, version)
 
 	d := &VolumeDriver{}
 	d.name = driverName
-	d.nodeID = nodeID
 	d.version = version
 	d.endpoint = endpoint
 	d.cluster = cluster

--- a/manifest/plugin/csi-bizflycloud-controllerplugin.yaml
+++ b/manifest/plugin/csi-bizflycloud-controllerplugin.yaml
@@ -78,7 +78,6 @@ spec:
           imagePullPolicy: "Always"
           args :
             - /bin/csi-bizflycloud
-            - "--nodeid=$(NODE_ID)"
             - "--endpoint=unix:///var/lib/csi/sockets/pluginproxy/csi.sock"
             - "--cluster=kubernetes"
             - "--is_control_plane=true"
@@ -88,10 +87,6 @@ spec:
             - "--tenant_id=$(BIZFLYCLOUD_TENANT_ID)"
             - "--region=$(BIZFLYCLOUD_REGION)"
           env:
-            - name: NODE_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
             - name: BIZFLYCLOUD_APPLICATION_CREDENTIAL_ID
               valueFrom:
                 secretKeyRef:

--- a/manifest/plugin/csi-bizflycloud-nodeplugin.yaml
+++ b/manifest/plugin/csi-bizflycloud-nodeplugin.yaml
@@ -52,13 +52,8 @@ spec:
           imagePullPolicy: "Always"
           args :
             - /bin/csi-bizflycloud
-            - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
           env:
-            - name: NODE_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock
           volumeMounts:


### PR DESCRIPTION
`--nodeid` flag is doing nothing, so it need cleaning up. But to keep backward compatible, marking it as deprecated for now