### PR TITLE
Update csi-driver.yaml

### DIFF
--- a/manifest/plugin/csi-driver.yaml
+++ b/manifest/plugin/csi-driver.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: volume.csi.bizflycloud.vn


### PR DESCRIPTION
Updated storage.k8s.io/v1beta1 to storage.k8s.io/v1

Error when apply to api v1beta1:

```
root@lab-bke-vpn-seed-worker-1:~# kubectl apply -f https://raw.githubusercontent.com/bizflycloud/csi-bizflycloud/master/manifest/plugin/csi-driver.yaml
error: resource mapping not found for name: "volume.csi.bizflycloud.vn" namespace: "" from "https://raw.githubusercontent.com/bizflycloud/csi-bizflycloud/master/manifest/plugin/csi-driver.yaml
": no matches for kind "CSIDriver" in version "storage.k8s.io/v1beta1
```

ref: https://github.com/linode/linode-blockstorage-csi-driver/pull/84